### PR TITLE
Move GAC Scores + General Cleanup

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -933,7 +933,7 @@ export async function updateCommunityModel(
 
           // Update existing principles and add new ones
           for (const principle of principles) {
-            if (principle.id.startsWith('new-')) {
+            if (principle.id.startsWith("new-")) {
               // This is a new principle, create it
               const newStatement = await prisma.statement.create({
                 data: {
@@ -958,10 +958,12 @@ export async function updateCommunityModel(
           }
 
           // Get all principle IDs, including newly created ones
-          const allPrincipleIds = updatedPrinciples.map(p => p.uid);
+          const allPrincipleIds = updatedPrinciples.map((p) => p.uid);
 
           // Find principles that are no longer in the list
-          const statementsToDelete = poll.statements.filter(s => !allPrincipleIds.includes(s.uid));
+          const statementsToDelete = poll.statements.filter(
+            (s) => !allPrincipleIds.includes(s.uid),
+          );
 
           // Delete principles that are no longer in the list
           for (const statement of statementsToDelete) {

--- a/lib/components/ConstitutionableExplanation.tsx
+++ b/lib/components/ConstitutionableExplanation.tsx
@@ -1,14 +1,20 @@
-import React from 'react';
+import React from "react";
 
 const ConstitutionableExplanation: React.FC = () => {
   return (
     <div className="max-w-2xl mx-auto">
       <h2 className="text-2xl font-bold mb-4">Constitutionable Statements</h2>
       <p className="mb-4">
-        Whether a statement is considered "Constitutionable" depends on our consensus scoring mechanism, which attempts to determine the principles with the highest consensus among participants. The goal is to identify principles that have broad agreement within the community, making them suitable candidates for inclusion in a constitution.
+        Whether a statement is considered "Constitutionable" depends on our
+        consensus scoring mechanism, which attempts to determine the principles
+        with the highest consensus among participants. The goal is to identify
+        principles that have broad agreement within the community, making them
+        suitable candidates for inclusion in a constitution.
       </p>
       <p>
-        Keep in mind that this is a dynamic process. As more people participate and vote, the consensus scores and "Constitutionable" status of statements may change over time.
+        Keep in mind that this is a dynamic process. As more people participate
+        and vote, the consensus scores and "Constitutionable" status of
+        statements may change over time.
       </p>
     </div>
   );

--- a/lib/components/ConstitutionableExplanation.tsx
+++ b/lib/components/ConstitutionableExplanation.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const ConstitutionableExplanation: React.FC = () => {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Constitutionable Statements</h2>
+      <p className="mb-4">
+        Whether a statement is considered "Constitutionable" depends on our consensus scoring mechanism, which attempts to determine the principles with the highest consensus among participants. The goal is to identify principles that have broad agreement within the community, making them suitable candidates for inclusion in a constitution.
+      </p>
+      <p>
+        Keep in mind that this is a dynamic process. As more people participate and vote, the consensus scores and "Constitutionable" status of statements may change over time.
+      </p>
+    </div>
+  );
+};
+
+export default ConstitutionableExplanation;

--- a/lib/components/Principle.tsx
+++ b/lib/components/Principle.tsx
@@ -15,7 +15,6 @@ interface PrincipleProps {
 const Principle: React.FC<PrincipleProps> = ({
   text,
   isLoading,
-  gacScore,
   onUpdate,
   onDelete,
   isEditing,
@@ -103,11 +102,6 @@ const Principle: React.FC<PrincipleProps> = ({
       </div>
       {!isLoading && (
         <div className="flex items-center space-x-2 ml-2">
-          {gacScore !== undefined && (
-            <span className="text-sm text-gray-500">
-              Score: {Number(gacScore.toFixed(2))}
-            </span>
-          )}
           <button
             onClick={() => setShowDeleteModal(true)}
             className="text-red-500 hover:text-red-700"

--- a/lib/components/flow/PollZone.tsx
+++ b/lib/components/flow/PollZone.tsx
@@ -238,25 +238,34 @@ export default function PollZone({
                     className="shadow rounded-lg flex flex-col overflow-hidden relative bg-soft-gray"
                   >
                     <div className="flex flex-col sm:flex-row justify-between items-start p-4">
-                      <div className="flex-grow pr-0 sm:pr-4 mb-4 sm:mb-0 min-h-[80px] sm:min-h-[60px] w-full sm:w-2/3"> 
+                      <div className="flex-grow pr-0 sm:pr-4 mb-4 sm:mb-0 min-h-[80px] sm:min-h-[60px] w-full sm:w-2/3">
                         <p>{statement.text}</p>
                       </div>
                       <div className="w-full sm:w-1/3 text-sm flex flex-row sm:flex-col items-start sm:items-end space-x-2 sm:space-x-0 sm:space-y-1">
                         <span className="bg-slate-blue text-white px-2 py-1 rounded text-center w-1/2 sm:w-full">
-                          {total > 0 ? "Consensus Score: " + Number(statement.gacScore?.toFixed(2) || 0) : "No Votes Yet"}
+                          {total > 0
+                            ? "Consensus Score: " +
+                              Number(statement.gacScore?.toFixed(2) || 0)
+                            : "No Votes Yet"}
                         </span>
                         <span
                           className={`px-2 py-1 rounded text-center w-1/2 sm:w-full ${
-                            isConstitutionable ? "bg-slate-blue text-white" : "bg-black bg-opacity-10 text-black text-opacity-50"
+                            isConstitutionable
+                              ? "bg-slate-blue text-white"
+                              : "bg-black bg-opacity-10 text-black text-opacity-50"
                           } cursor-pointer flex items-center justify-center`}
                           onClick={() => setIsExplanationModalOpen(true)}
                         >
-                          {isConstitutionable ? "Constitutionable" : "Not Constitutionable"}
+                          {isConstitutionable
+                            ? "Constitutionable"
+                            : "Not Constitutionable"}
                           <FaQuestionCircle className="ml-1 text-xs" />
                         </span>
                       </div>
                     </div>
-                    <div className={`flex flex-col sm:flex-row text-white text-sm mt-1 ml-4 mr-4 mb-4 rounded-md overflow-hidden ${total > 0 ? "opacity-95" : "opacity-70"}`}>
+                    <div
+                      className={`flex flex-col sm:flex-row text-white text-sm mt-1 ml-4 mr-4 mb-4 rounded-md overflow-hidden ${total > 0 ? "opacity-95" : "opacity-70"}`}
+                    >
                       <div className="flex flex-col sm:flex-row flex-grow">
                         <div
                           className="flex bg-agree-green"

--- a/lib/components/flow/PollZone.tsx
+++ b/lib/components/flow/PollZone.tsx
@@ -9,11 +9,18 @@ import {
   FaShareAlt,
   FaSync,
   FaVoteYea,
+  FaQuestionCircle,
 } from "react-icons/fa";
 import { Poll, Statement } from "@prisma/client";
 import Button from "@/lib/components/Button";
 import { fetchPollData } from "@/lib/actions";
 import { isStatementConstitutionable } from "@/lib/utils/pollUtils";
+import Modal from "@/lib/components/Modal";
+import ConstitutionableExplanation from "@/lib/components/ConstitutionableExplanation";
+
+interface ExtendedPoll extends Poll {
+  statements: Statement[];
+}
 
 interface PollZoneProps {
   isActive: boolean;
@@ -26,7 +33,7 @@ interface PollZoneProps {
     requireAuth: boolean;
     allowContributions: boolean;
   };
-  pollData?: Poll & { statements: Statement[] }; // Update this type
+  pollData?: ExtendedPoll;
   isExistingModel: boolean;
   onToggle: () => void;
   savingStatus: "idle" | "saving" | "saved";
@@ -48,6 +55,7 @@ export default function PollZone({
   const [localPollData, setLocalPollData] = useState(pollData);
   const [showAllStatements, setShowAllStatements] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isExplanationModalOpen, setIsExplanationModalOpen] = useState(false);
 
   useEffect(() => {
     if (pollData) {
@@ -227,22 +235,38 @@ export default function PollZone({
                 return (
                   <li
                     key={index}
-                    className="shadow rounded-lg flex flex-col overflow-hidden"
+                    className="shadow rounded-lg flex flex-col overflow-hidden relative bg-soft-gray"
                   >
-                    <div className="p-4 bg-soft-gray">
-                      <p>{statement.text}</p>
+                    <div className="flex flex-col sm:flex-row justify-between items-start p-4">
+                      <div className="flex-grow pr-0 sm:pr-4 mb-4 sm:mb-0 min-h-[80px] sm:min-h-[60px] w-full sm:w-2/3"> 
+                        <p>{statement.text}</p>
+                      </div>
+                      <div className="w-full sm:w-1/3 text-sm flex flex-row sm:flex-col items-start sm:items-end space-x-2 sm:space-x-0 sm:space-y-1">
+                        <span className="bg-slate-blue text-white px-2 py-1 rounded text-center w-1/2 sm:w-full">
+                          {total > 0 ? "Consensus Score: " + Number(statement.gacScore?.toFixed(2) || 0) : "No Votes Yet"}
+                        </span>
+                        <span
+                          className={`px-2 py-1 rounded text-center w-1/2 sm:w-full ${
+                            isConstitutionable ? "bg-slate-blue text-white" : "bg-black bg-opacity-10 text-black text-opacity-50"
+                          } cursor-pointer flex items-center justify-center`}
+                          onClick={() => setIsExplanationModalOpen(true)}
+                        >
+                          {isConstitutionable ? "Constitutionable" : "Not Constitutionable"}
+                          <FaQuestionCircle className="ml-1 text-xs" />
+                        </span>
+                      </div>
                     </div>
-                    <div className="flex text-white text-sm">
-                      <div className="flex flex-grow">
+                    <div className={`flex flex-col sm:flex-row text-white text-sm mt-1 ml-4 mr-4 mb-4 rounded-md overflow-hidden ${total > 0 ? "opacity-95" : "opacity-70"}`}>
+                      <div className="flex flex-col sm:flex-row flex-grow">
                         <div
                           className="flex bg-agree-green"
                           style={{
                             flexGrow: agreeRatio,
                             flexBasis: flexBasis,
-                            minWidth: areAllEqual ? "auto" : "60px",
+                            minWidth: "7em",
                           }}
                         >
-                          <span className="py-2 px-4 whitespace-nowrap">
+                          <span className="py-1 px-2 whitespace-nowrap w-full text-center">
                             Agree: {statement.agreeCount}
                           </span>
                         </div>
@@ -251,10 +275,10 @@ export default function PollZone({
                           style={{
                             flexGrow: disagreeRatio,
                             flexBasis: flexBasis,
-                            minWidth: areAllEqual ? "auto" : "60px",
+                            minWidth: "7em",
                           }}
                         >
-                          <span className="py-2 px-4 whitespace-nowrap">
+                          <span className="py-1 px-2 whitespace-nowrap w-full text-center">
                             Disagree: {statement.disagreeCount}
                           </span>
                         </div>
@@ -263,24 +287,13 @@ export default function PollZone({
                           style={{
                             flexGrow: skipRatio,
                             flexBasis: flexBasis,
-                            minWidth: areAllEqual ? "auto" : "60px",
+                            minWidth: "7em",
                           }}
                         >
-                          <span className="py-2 px-4 whitespace-nowrap">
+                          <span className="py-1 px-2 whitespace-nowrap w-full text-center">
                             Skip: {statement.passCount}
                           </span>
                         </div>
-                      </div>
-                      <div
-                        className={`w-1/4 py-2 px-4 text-center ${
-                          isConstitutionable
-                            ? "bg-slate-blue"
-                            : "bg-medium-gray"
-                        }`}
-                      >
-                        {isConstitutionable
-                          ? "Constitutionable"
-                          : "Not Constitutionable"}
                       </div>
                     </div>
                   </li>
@@ -339,6 +352,12 @@ export default function PollZone({
           )}
         </div>
       </div>
+      <Modal
+        isOpen={isExplanationModalOpen}
+        onClose={() => setIsExplanationModalOpen(false)}
+      >
+        <ConstitutionableExplanation />
+      </Modal>
     </ZoneWrapper>
   );
 }

--- a/lib/components/flow/PrinciplesZone.tsx
+++ b/lib/components/flow/PrinciplesZone.tsx
@@ -85,12 +85,10 @@ export default function PrinciplesZone({
         p.id === id ? { ...p, text: value.trim(), isEditing: false } : p,
       );
 
-      const formattedPrinciples = newPrinciples.map(
-        ({ id, text }) => ({
-          id,
-          text,
-        }),
-      );
+      const formattedPrinciples = newPrinciples.map(({ id, text }) => ({
+        id,
+        text,
+      }));
 
       debouncedUpdateModelData({ principles: formattedPrinciples });
 
@@ -102,12 +100,10 @@ export default function PrinciplesZone({
     setPrinciples((prevPrinciples) => {
       const newPrinciples = prevPrinciples.filter((p) => p.id !== id);
 
-      const formattedPrinciples = newPrinciples.map(
-        ({ id, text }) => ({
-          id,
-          text,
-        }),
-      );
+      const formattedPrinciples = newPrinciples.map(({ id, text }) => ({
+        id,
+        text,
+      }));
 
       debouncedUpdateModelData({ principles: formattedPrinciples });
 

--- a/lib/components/flow/PrinciplesZone.tsx
+++ b/lib/components/flow/PrinciplesZone.tsx
@@ -14,7 +14,6 @@ interface PrinciplesZoneProps {
     principles: Array<{
       id: string;
       text: string;
-      gacScore?: number;
     }>;
     requireAuth: boolean;
     allowContributions: boolean;
@@ -31,7 +30,6 @@ interface PrincipleData {
   id: string;
   text: string;
   isLoading: boolean;
-  gacScore?: number;
   isEditing: boolean;
 }
 
@@ -54,7 +52,6 @@ export default function PrinciplesZone({
           text: typeof p === "string" ? p : p.text,
           isLoading: false,
           isEditing: false,
-          gacScore: typeof p === "object" ? p.gacScore : undefined,
         }))
       : [];
   });
@@ -89,10 +86,9 @@ export default function PrinciplesZone({
       );
 
       const formattedPrinciples = newPrinciples.map(
-        ({ id, text, gacScore }) => ({
+        ({ id, text }) => ({
           id,
           text,
-          gacScore,
         }),
       );
 
@@ -107,10 +103,9 @@ export default function PrinciplesZone({
       const newPrinciples = prevPrinciples.filter((p) => p.id !== id);
 
       const formattedPrinciples = newPrinciples.map(
-        ({ id, text, gacScore }) => ({
+        ({ id, text }) => ({
           id,
           text,
-          gacScore,
         }),
       );
 
@@ -201,7 +196,6 @@ export default function PrinciplesZone({
                 key={principle.id}
                 text={principle.text}
                 isLoading={principle.isLoading}
-                gacScore={principle.gacScore}
                 onUpdate={(value) => updatePrinciple(principle.id, value)}
                 onDelete={() => removePrinciple(principle.id)}
                 isEditing={principle.isEditing}


### PR DESCRIPTION
I think it makes more sense to have scores in the results area and keep the editing area for removing/adding principles - Thoughts?

- Move GAC Score to poll results area
- Try to improve layout of statement results
- Add modal with little placeholder explanation of what it means for something to be constitutionable

# **Before:**

------

<img width="741" alt="Screenshot 2024-10-14 at 18 07 13" src="https://github.com/user-attachments/assets/f7f4f726-b000-43dc-a6db-6f864350ab72">

------

<img width="742" alt="Screenshot 2024-10-14 at 18 07 07" src="https://github.com/user-attachments/assets/5a4f9539-f64c-45f2-8a50-0905465834bc">

------

# **After:**

------

<img width="709" alt="Screenshot 2024-10-14 at 18 09 33" src="https://github.com/user-attachments/assets/4404543d-1ce8-4239-bbf2-8e3d952d5d74">

------
<img width="763" alt="Screenshot 2024-10-14 at 18 09 43" src="https://github.com/user-attachments/assets/f88a4098-1fcb-4e8b-b606-61e11b865764">

------

<img width="1043" alt="Screenshot 2024-10-14 at 18 09 37" src="https://github.com/user-attachments/assets/a9e768a9-72fc-46c4-a853-f732aaf39c28">


