### PR TITLE
Auto constitution

### DIFF
--- a/COMMUNITY_MODELS_API.md
+++ b/COMMUNITY_MODELS_API.md
@@ -67,11 +67,13 @@ Submit a vote on a statement. The API key must be associated with the Community 
 ```
 
 ### Create Constitution
+
 `POST /api/models/{modelId}/constitutions`
 
 Create a new constitution from the current set of constitutionable statements and set it as the active constitution. The API key must be associated with the Community Model.
 
 **Response:**
+
 ```json
 {
   "uid": "constitution-id",

--- a/COMMUNITY_MODELS_API.md
+++ b/COMMUNITY_MODELS_API.md
@@ -66,6 +66,22 @@ Submit a vote on a statement. The API key must be associated with the Community 
 }
 ```
 
+### Create Constitution
+`POST /api/models/{modelId}/constitutions`
+
+Create a new constitution from the current set of constitutionable statements and set it as the active constitution. The API key must be associated with the Community Model.
+
+**Response:**
+```json
+{
+  "uid": "constitution-id",
+  "version": 1,
+  "status": "ACTIVE",
+  "content": "Constitution content...",
+  "createdAt": "2024-01-15T00:00:00Z"
+}
+```
+
 ### Chat Completions
 
 `POST /api/v1/chat/completions`

--- a/apps/consensus-service/api/test_webhook.py
+++ b/apps/consensus-service/api/test_webhook.py
@@ -1,0 +1,59 @@
+import asyncio
+import os
+from webhook_utils import send_webhook
+from update_gac_scores import setup_logging
+from dotenv import load_dotenv
+import pathlib
+
+logger = setup_logging()
+
+def load_env():
+    """Load environment variables from .env.local or .env"""
+    env_dir = pathlib.Path(__file__).parent.parent
+    local_env = env_dir / '.env.local'
+    default_env = env_dir / '.env'
+    
+    if local_env.exists():
+        logger.info("Loading .env.local")
+        load_dotenv(local_env)
+    elif default_env.exists():
+        logger.info("Loading .env")
+        load_dotenv(default_env)
+    else:
+        logger.warning("No .env file found")
+
+async def test_webhook():
+    """Test webhook functionality by sending a test event."""
+    # You can replace these with actual IDs from your database
+    test_model_id = "test_model_123"
+    test_poll_id = "test_poll_456"
+    
+    logger.info(f"Testing webhook with model_id={test_model_id}, poll_id={test_poll_id}")
+    
+    success = await send_webhook(test_model_id, test_poll_id)
+    
+    if success:
+        logger.info("✅ Webhook test successful!")
+    else:
+        logger.error("❌ Webhook test failed!")
+
+def main():
+    """Main function to run the webhook test."""
+    # Load environment variables
+    load_env()
+    
+    # Check required environment variables
+    required_vars = ['WEBHOOK_URL', 'WEBHOOK_SECRET']
+    missing_vars = [var for var in required_vars if not os.getenv(var)]
+    
+    if missing_vars:
+        logger.error(f"Missing required environment variables: {', '.join(missing_vars)}")
+        return
+        
+    logger.info(f"Using webhook URL: {os.getenv('WEBHOOK_URL')}")
+    
+    # Run the async test
+    asyncio.run(test_webhook())
+
+if __name__ == "__main__":
+    main() 

--- a/apps/consensus-service/api/test_webhook_with_db.py
+++ b/apps/consensus-service/api/test_webhook_with_db.py
@@ -1,0 +1,89 @@
+import asyncio
+import os
+from webhook_utils import send_webhook
+from update_gac_scores import setup_logging, create_connection
+from dotenv import load_dotenv
+import pathlib
+
+logger = setup_logging()
+
+def load_env():
+    """Load environment variables from .env.local file"""
+    env_dir = pathlib.Path(__file__).parent.parent
+    local_env = env_dir / '.env.local'
+    
+    if not local_env.exists():
+        logger.error(".env.local not found")
+        return False
+    
+    # Clear any existing environment variables that we care about
+    for key in ['DATABASE_URL', 'WEBHOOK_URL', 'WEBHOOK_SECRET']:
+        if key in os.environ:
+            del os.environ[key]
+            
+    logger.info("Loading .env.local (local config)")
+    load_dotenv(local_env)
+    return True
+
+async def test_webhook_with_db():
+    """Test webhook functionality using real data from database."""
+    try:
+        # Create DB connection
+        conn = create_connection()
+        cursor = conn.cursor()
+        
+        # Get a real model and poll ID from the database
+        cursor.execute("""
+            SELECT p.uid as poll_id, p."communityModelId" as model_id
+            FROM "Poll" p
+            JOIN "CommunityModel" cm ON p."communityModelId" = cm.uid
+            WHERE NOT p.deleted AND NOT cm.deleted
+            LIMIT 1;
+        """)
+        
+        result = cursor.fetchone()
+        if not result:
+            logger.error("No valid poll found in database")
+            return
+            
+        poll_id, model_id = result
+        
+        logger.info(f"Testing webhook with real data:")
+        logger.info(f"  Model ID: {model_id}")
+        logger.info(f"  Poll ID: {poll_id}")
+        
+        success = await send_webhook(model_id, poll_id)
+        
+        if success:
+            logger.info("✅ Webhook test successful!")
+        else:
+            logger.error("❌ Webhook test failed!")
+            
+    except Exception as e:
+        logger.error(f"Error during test: {e}")
+    finally:
+        cursor.close()
+        conn.close()
+
+def main():
+    """Main function to run the webhook test."""
+    # Load environment variables from .env.local
+    if not load_env():
+        return
+    
+    # Check required environment variables
+    required_vars = ['WEBHOOK_URL', 'WEBHOOK_SECRET', 'DATABASE_URL']
+    missing_vars = [var for var in required_vars if not os.getenv(var)]
+    
+    if missing_vars:
+        logger.error(f"Missing required environment variables: {', '.join(missing_vars)}")
+        return
+        
+    logger.info(f"Using webhook URL: {os.getenv('WEBHOOK_URL')}")
+    logger.info(f"Using database URL: {os.getenv('DATABASE_URL')}")
+    
+    # Run the async test
+    asyncio.run(test_webhook_with_db())
+
+if __name__ == "__main__":
+    main() 

--- a/apps/consensus-service/api/update_gac_scores.py
+++ b/apps/consensus-service/api/update_gac_scores.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import numpy as np
 import pandas as pd
 import math
+import aiohttp
 
 # Set pandas option for future-proof behavior with downcasting
 pd.set_option('future.no_silent_downcasting', True)
@@ -129,6 +130,81 @@ def verify_poll_exists(cursor, poll_id):
     
     return True
 
+def get_community_model_id(cursor, poll_id):
+    """Get the community model ID and auto-create setting for a given poll."""
+    cursor.execute("""
+        SELECT "communityModelId", "autoCreateConstitution"
+        FROM "Poll"
+        JOIN "CommunityModel" ON "Poll"."communityModelId" = "CommunityModel".uid
+        WHERE "Poll".uid = %s;
+    """, (poll_id,))
+    result = cursor.fetchone()
+    if not result:
+        return None, False
+    return result[0], result[1]
+
+def get_constitutionable_statements(cursor, poll_id):
+    """Get the set of constitutionable statement IDs for a poll."""
+    cursor.execute("""
+        SELECT uid FROM "Statement"
+        WHERE "pollId" = %s AND "isConstitutionable" = TRUE;
+    """, (poll_id,))
+    return {row[0] for row in cursor.fetchall()}
+
+async def create_constitution(model_id: str):
+    """Create a new constitution using the API endpoint."""
+    api_url = f"{os.getenv('API_BASE_URL', 'http://localhost:3000')}/api/models/{model_id}/constitutions"
+    api_key = os.getenv('API_KEY')
+    
+    if not api_key:
+        logger.error("API_KEY environment variable not set")
+        return False
+        
+    try:
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json'
+        }
+        
+        async with aiohttp.ClientSession() as session:
+            async with session.post(api_url, headers=headers) as response:
+                if response.status == 200:
+                    logger.info(f"Successfully created new constitution for model {model_id}")
+                    return True
+                else:
+                    error_data = await response.json()
+                    logger.error(f"Failed to create constitution: {error_data.get('error', 'Unknown error')}")
+                    return False
+                    
+    except Exception as e:
+        logger.error(f"Error creating constitution via API: {e}")
+        return False
+
+def check_and_create_constitution(cursor, conn, poll_id, pre_update_statements):
+    """Check if constitution needs to be created and create if necessary."""
+    model_id, auto_create_enabled = get_community_model_id(cursor, poll_id)
+    
+    if not model_id or not auto_create_enabled:
+        return
+        
+    # Get post-update constitutionable statements
+    post_update_statements = get_constitutionable_statements(cursor, poll_id)
+    
+    # If there's a difference in the sets
+    if pre_update_statements != post_update_statements:
+        logger.info(f"Constitutionable statements changed for poll {poll_id}")
+        logger.info(f"Pre-update: {pre_update_statements}")
+        logger.info(f"Post-update: {post_update_statements}")
+        
+        # Use asyncio to call the async create_constitution function
+        import asyncio
+        success = asyncio.run(create_constitution(model_id))
+        
+        if success:
+            logger.info(f"Successfully created new constitution for model {model_id}")
+        else:
+            logger.error(f"Failed to create new constitution for model {model_id}")
+
 def main(poll_id=None, dry_run=False, force=False):
     """
     Main function to update GAC scores.
@@ -162,6 +238,10 @@ def main(poll_id=None, dry_run=False, force=False):
             try:
                 poll_id = poll['uid']
                 logger.info(f"Processing poll ID: {poll_id}")
+                
+                # Get pre-update constitutionable statements
+                pre_update_statements = get_constitutionable_statements(cursor, poll_id)
+                
                 statements, votes, participants = fetch_poll_data(cursor, poll_id)
                 logger.info(f"Fetched data for poll ID: {poll_id}")
 
@@ -186,6 +266,9 @@ def main(poll_id=None, dry_run=False, force=False):
                 else:
                     update_statements(cursor, conn, statements, gac_scores, votes)
                     logger.info(f"Updated GAC scores for poll ID: {poll_id}")
+                    
+                    # Check if we need to create a new constitution
+                    check_and_create_constitution(cursor, conn, poll_id, pre_update_statements)
 
             except Exception as e:
                 logger.error(f"Error processing poll ID {poll_id}: {e}")

--- a/apps/consensus-service/api/webhook_utils.py
+++ b/apps/consensus-service/api/webhook_utils.py
@@ -1,0 +1,76 @@
+import os
+import json
+import hmac
+import hashlib
+from datetime import datetime
+import aiohttp
+import logging
+
+logger = logging.getLogger(__name__)
+
+def create_signature(payload: dict, secret: str) -> str:
+    """Create HMAC signature for webhook payload."""
+    payload_str = json.dumps(payload)
+    return hmac.new(
+        secret.encode('utf-8'),
+        payload_str.encode('utf-8'),
+        hashlib.sha256
+    ).hexdigest()
+
+async def send_webhook(model_id: str, poll_id: str) -> bool:
+    """
+    Send webhook to notify about changes in constitutionable statements.
+    Returns True if webhook was successfully delivered.
+    """
+    webhook_url = os.getenv('WEBHOOK_URL')
+    webhook_secret = os.getenv('WEBHOOK_SECRET')
+    
+    if not webhook_url or not webhook_secret:
+        logger.error("Missing required environment variables: WEBHOOK_URL or WEBHOOK_SECRET")
+        return False
+        
+    payload = {
+        "event": "statements_changed",
+        "modelId": model_id,
+        "pollId": poll_id,
+        "timestamp": datetime.utcnow().isoformat()
+    }
+    
+    try:
+        # Create signature
+        signature = create_signature(payload, webhook_secret)
+        
+        # Prepare headers
+        headers = {
+            'Content-Type': 'application/json',
+            'X-Webhook-Signature': signature
+        }
+        
+        # Send webhook with retries
+        async with aiohttp.ClientSession() as session:
+            for attempt in range(3):  # Try up to 3 times
+                try:
+                    async with session.post(
+                        webhook_url,
+                        json=payload,
+                        headers=headers,
+                        timeout=10  # 10 second timeout
+                    ) as response:
+                        if response.status == 200:
+                            logger.info(f"Webhook delivered successfully for model {model_id}")
+                            return True
+                        else:
+                            error_data = await response.json()
+                            logger.error(f"Webhook delivery failed (attempt {attempt + 1}): {error_data}")
+                            
+                except aiohttp.ClientError as e:
+                    logger.error(f"Webhook request failed (attempt {attempt + 1}): {e}")
+                    if attempt == 2:  # Last attempt
+                        return False
+                    continue
+                    
+        return False
+        
+    except Exception as e:
+        logger.error(f"Error sending webhook: {e}")
+        return False 

--- a/apps/web/app/api/models/[modelId]/constitutions/route.ts
+++ b/apps/web/app/api/models/[modelId]/constitutions/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/db";
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { modelId: string } }
+  { params }: { params: { modelId: string } },
 ) {
   try {
     const modelId = params.modelId;
@@ -15,7 +15,7 @@ export async function POST(
     if (!authHeader?.startsWith("Bearer ")) {
       return NextResponse.json(
         { error: "Invalid authentication" },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -30,7 +30,7 @@ export async function POST(
     if (keyModelId !== modelId) {
       return NextResponse.json(
         { error: "API key is not authorized for this community model" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -42,7 +42,7 @@ export async function POST(
     console.error("Error creating constitution:", error);
     return NextResponse.json(
       { error: error.message || "Failed to create constitution" },
-      { status: 500 }
+      { status: 500 },
     );
   }
-} 
+}

--- a/apps/web/app/api/models/[modelId]/constitutions/route.ts
+++ b/apps/web/app/api/models/[modelId]/constitutions/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAndActivateConstitution } from "@/lib/actions";
+import { verifyApiKeyRequest } from "@/lib/api-auth";
+import { prisma } from "@/lib/db";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { modelId: string } }
+) {
+  try {
+    const modelId = params.modelId;
+
+    // Verify API key
+    const authHeader = request.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return NextResponse.json(
+        { error: "Invalid authentication" },
+        { status: 401 }
+      );
+    }
+
+    const apiKey = authHeader.slice(7);
+    const { modelId: keyModelId, isValid } = await verifyApiKeyRequest(apiKey);
+
+    if (!isValid) {
+      return NextResponse.json({ error: "Invalid API key" }, { status: 401 });
+    }
+
+    // Verify that the API key belongs to this community model
+    if (keyModelId !== modelId) {
+      return NextResponse.json(
+        { error: "API key is not authorized for this community model" },
+        { status: 403 }
+      );
+    }
+
+    // Create and activate new constitution
+    const constitution = await createAndActivateConstitution(modelId);
+
+    return NextResponse.json(constitution);
+  } catch (error: any) {
+    console.error("Error creating constitution:", error);
+    return NextResponse.json(
+      { error: error.message || "Failed to create constitution" },
+      { status: 500 }
+    );
+  }
+} 

--- a/apps/web/app/api/webhooks/consensus/route.ts
+++ b/apps/web/app/api/webhooks/consensus/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: NextRequest) {
       console.error("Webhook verification failed:", verificationResult.error);
       return NextResponse.json(
         { error: verificationResult.error },
-        { status: 401 }
+        { status: 401 },
       );
     }
 
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
         console.warn(`Unknown webhook event type: ${payload.event}`);
         return NextResponse.json(
           { error: "Unknown event type" },
-          { status: 400 }
+          { status: 400 },
         );
     }
 
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
     console.error("Error processing webhook:", error);
     return NextResponse.json(
       { error: error.message || "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
-} 
+}

--- a/apps/web/app/api/webhooks/consensus/route.ts
+++ b/apps/web/app/api/webhooks/consensus/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyWebhook } from "@/lib/utils/server/webhooks";
+import { createAndActivateConstitution } from "@/lib/actions";
+
+export async function POST(request: NextRequest) {
+  try {
+    // Get raw body and signature
+    const rawBody = await request.text();
+    const signature = request.headers.get("X-Webhook-Signature");
+
+    // Verify webhook
+    const verificationResult = verifyWebhook(signature, rawBody);
+    if (!verificationResult.isValid || !verificationResult.payload) {
+      console.error("Webhook verification failed:", verificationResult.error);
+      return NextResponse.json(
+        { error: verificationResult.error },
+        { status: 401 }
+      );
+    }
+
+    const { payload } = verificationResult;
+
+    // Handle different event types
+    switch (payload.event) {
+      case "statements_changed":
+        // Create and activate new constitution
+        await createAndActivateConstitution(payload.modelId);
+        break;
+      default:
+        console.warn(`Unknown webhook event type: ${payload.event}`);
+        return NextResponse.json(
+          { error: "Unknown event type" },
+          { status: 400 }
+        );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    console.error("Error processing webhook:", error);
+    return NextResponse.json(
+      { error: error.message || "Internal server error" },
+      { status: 500 }
+    );
+  }
+} 

--- a/apps/web/lib/actions.ts
+++ b/apps/web/lib/actions.ts
@@ -953,6 +953,7 @@ export async function updateCommunityModel(
     allowContributions?: boolean;
     constitutions?: Constitution[];
     activeConstitutionId?: string | null;
+    autoCreateConstitution?: boolean;
   },
 ): Promise<CommunityModel & { polls: Poll[] }> {
   const {
@@ -961,6 +962,7 @@ export async function updateCommunityModel(
     allowContributions,
     constitutions,
     activeConstitutionId,
+    autoCreateConstitution,
     ...modelData
   } = data;
 
@@ -972,6 +974,9 @@ export async function updateCommunityModel(
           where: { uid: modelId },
           data: {
             ...modelData,
+            ...(autoCreateConstitution !== undefined && {
+              autoCreateConstitution,
+            }),
             activeConstitutionId:
               activeConstitutionId !== undefined
                 ? activeConstitutionId

--- a/apps/web/lib/actions.ts
+++ b/apps/web/lib/actions.ts
@@ -6,6 +6,7 @@ import type {
   ClerkEmailAddress,
   ExtendedStatement,
   ExtendedPoll,
+  Principle,
 } from "@/lib/types";
 import type {
   Poll,
@@ -948,7 +949,7 @@ export async function updateConstitution(
 export async function updateCommunityModel(
   modelId: string,
   data: Partial<CommunityModel> & {
-    principles?: Array<{ id: string; text: string; gacScore?: number }>;
+    principles?: Principle[];
     requireAuth?: boolean;
     allowContributions?: boolean;
     constitutions?: Constitution[];

--- a/apps/web/lib/actions.ts
+++ b/apps/web/lib/actions.ts
@@ -634,7 +634,7 @@ async function createInitialPoll(
 
 export async function createCommunityModel(
   data: Partial<CommunityModel> & {
-    principles?: Array<{ id: string; text: string; gacScore?: number }>;
+    principles?: Principle[];
   },
 ) {
   const { userId: clerkUserId } = auth();
@@ -668,6 +668,7 @@ export async function createCommunityModel(
                   create: data.principles.map((principle) => ({
                     text: principle.text,
                     participantId: owner.participantId!,
+                    gacScore: principle.gacScore,
                   })),
                 }
               : undefined,

--- a/apps/web/lib/actions.ts
+++ b/apps/web/lib/actions.ts
@@ -1302,3 +1302,11 @@ export async function checkPollCompletion(
     currentSubmissions: submissionCount,
   };
 }
+
+export async function createAndActivateConstitution(
+  modelId: string,
+): Promise<Constitution> {
+  const constitution = await createConstitution(modelId);
+  await setActiveConstitution(modelId, constitution.uid);
+  return constitution;
+}

--- a/apps/web/lib/components/CommunityModelFlow.tsx
+++ b/apps/web/lib/components/CommunityModelFlow.tsx
@@ -210,16 +210,20 @@ export default function CommunityModelFlow({
     if (modelId) {
       try {
         setSavingStatus((prev) => ({ ...prev, principles: "saving" }));
+        const updatedPrinciples = data.principles ? data.principles.map(p => ({ id: p.id, text: p.text, gacScore: p.gacScore ?? 0 })) : undefined;
         const updatedModel = await updateCommunityModel(modelId, {
-          principles: data.principles,
+          principles: updatedPrinciples,
           requireAuth: data.requireAuth,
           allowContributions: data.allowContributions,
         });
+
         setModelData((prevData) => {
           if (!prevData) return null;
+          const { principles, ...otherData } = data;
           const newData = {
             ...prevData,
-            ...data,
+            ...otherData,
+            principles: updatedPrinciples || prevData.principles,
             polls: [...updatedModel.polls],
           } as ExtendedAboutZoneData;
           console.log("Updated model data:", newData);
@@ -391,7 +395,15 @@ export default function CommunityModelFlow({
                   allowContributions: modelData.allowContributions || false,
                 }}
                 updateModelData={(data) => {
-                  handleUpdatePrinciples(data);
+                  const transformedData = {
+                    ...data,
+                    principles: data.principles ? ((data.principles as Partial<Principle>[]).map(p => ({
+                      id: p.id!,
+                      text: p.text!,
+                      gacScore: p.gacScore ?? 0
+                    })) as Principle[]) : undefined
+                  };
+                  handleUpdatePrinciples(transformedData);
                 }}
                 isExistingModel={isExistingModel}
                 onToggle={() => toggleZone("principles")}

--- a/apps/web/lib/components/CommunityModelFlow.tsx
+++ b/apps/web/lib/components/CommunityModelFlow.tsx
@@ -48,12 +48,6 @@ interface ZoneRefs {
   [key: string]: React.RefObject<HTMLDivElement>;
 }
 
-interface Principle {
-  id: string;
-  text: string;
-  gacScore: number | null;
-}
-
 export default function CommunityModelFlow({
   initialModelId,
 }: CommunityModelFlowProps) {
@@ -176,18 +170,23 @@ export default function CommunityModelFlow({
     fetchModelData();
   }, [modelId, router, handleHashChange]);
 
-  const handleSaveAbout = async (data: AboutZoneData) => {
+  const handleAboutSubmit = async (data: Partial<ExtendedAboutZoneData>) => {
+    setSavingStatus((prev) => ({ ...prev, about: "saving" }));
     setIsSaving(true);
     try {
       if (!modelId) {
         const newModelId = await createCommunityModel({
-          name: data.name,
-          bio: data.bio,
-          goal: data.goal,
-          logoUrl: data.logoUrl,
+          name: data.name || "",
+          bio: data.bio || "",
+          goal: data.goal || "",
+          principles: data.principles?.map((p) => ({
+            id: p.id,
+            text: p.text,
+            gacScore: p.gacScore ?? null
+          })),
         });
         setModelId(newModelId);
-        router.push(`/community-models/flow/${newModelId}`);
+        router.push(`/community-models/${newModelId}`);
       } else {
         await updateCommunityModel(modelId, data);
       }
@@ -357,7 +356,7 @@ export default function CommunityModelFlow({
         <div ref={zoneRefs.about} id="about">
           <AboutZone
             isActive={activeZones.includes("about")}
-            onSave={handleSaveAbout}
+            onSave={handleAboutSubmit}
             initialData={modelData || undefined}
             isExistingModel={isExistingModel}
             modelId={modelId || undefined}

--- a/apps/web/lib/components/CommunityModelFlow.tsx
+++ b/apps/web/lib/components/CommunityModelFlow.tsx
@@ -182,7 +182,7 @@ export default function CommunityModelFlow({
           principles: data.principles?.map((p) => ({
             id: p.id,
             text: p.text,
-            gacScore: p.gacScore
+            gacScore: p.gacScore ?? null
           })),
         });
         setModelId(newModelId);

--- a/apps/web/lib/components/CommunityModelFlow.tsx
+++ b/apps/web/lib/components/CommunityModelFlow.tsx
@@ -31,6 +31,7 @@ interface ExtendedAboutZoneData extends AboutZoneData {
   published?: boolean;
   apiEnabled?: boolean;
   advancedOptionsEnabled?: boolean;
+  autoCreateConstitution?: boolean;
   apiKeys?: ApiKey[];
   owner?: {
     uid: string;
@@ -145,6 +146,8 @@ export default function CommunityModelFlow({
               apiEnabled: fetchedModelData.apiEnabled || false,
               advancedOptionsEnabled:
                 fetchedModelData.advancedOptionsEnabled || false,
+              autoCreateConstitution:
+                fetchedModelData.autoCreateConstitution || false,
               apiKeys: fetchedModelData.apiKeys || [],
               owner: fetchedModelData.owner,
             });
@@ -506,6 +509,20 @@ export default function CommunityModelFlow({
                   savingStatus={savingStatus.advanced}
                   apiEnabled={modelData.apiEnabled}
                   advancedOptionsEnabled={modelData.advancedOptionsEnabled}
+                  autoCreateConstitution={modelData.autoCreateConstitution}
+                  onUpdateAutoCreateConstitution={(enabled) => {
+                    setModelData((prevData) => {
+                      if (!prevData) return null;
+                      return {
+                        ...prevData,
+                        autoCreateConstitution: enabled,
+                      } as ExtendedAboutZoneData;
+                    });
+                    debouncedSaveModelData(
+                      { autoCreateConstitution: enabled },
+                      "advanced",
+                    );
+                  }}
                   pollOptions={
                     modelData.polls?.[0] || {
                       minVotesBeforeSubmission: null,

--- a/apps/web/lib/components/CommunityModelFlow.tsx
+++ b/apps/web/lib/components/CommunityModelFlow.tsx
@@ -19,10 +19,10 @@ import Toast from "./Toast";
 import { debounce } from "lodash";
 import { Constitution, Poll, Statement, ApiKey, Vote } from "@prisma/client";
 import Spinner from "./Spinner";
-import type { ExtendedPoll } from "@/lib/types";
+import type { ExtendedPoll, Principle } from "@/lib/types";
 
 interface ExtendedAboutZoneData extends AboutZoneData {
-  principles: Array<{ id: string; text: string; gacScore?: number }>;
+  principles: Principle[];
   requireAuth: boolean;
   allowContributions: boolean;
   constitutions: Constitution[];
@@ -51,7 +51,7 @@ interface ZoneRefs {
 interface Principle {
   id: string;
   text: string;
-  gacScore?: number;
+  gacScore: number | null;
 }
 
 export default function CommunityModelFlow({
@@ -127,15 +127,11 @@ export default function CommunityModelFlow({
               bio: fetchedModelData.bio || "",
               goal: fetchedModelData.goal || "",
               logoUrl: fetchedModelData.logoUrl || "",
-              principles: fetchedModelData.principles.map(
-                (p: string | Principle) =>
-                  typeof p === "string"
-                    ? {
-                        id: `principle-${Date.now()}-${Math.random()}`,
-                        text: p,
-                      }
-                    : p,
-              ),
+              principles: fetchedModelData.principles.map((p) => ({
+                id: p.id,
+                text: p.text,
+                gacScore: p.gacScore,
+              })),
               requireAuth: fetchedModelData.requireAuth || false,
               allowContributions: fetchedModelData.allowContributions || false,
               constitutions: fetchedModelData.constitutions || [],
@@ -148,8 +144,12 @@ export default function CommunityModelFlow({
                 fetchedModelData.advancedOptionsEnabled || false,
               autoCreateConstitution:
                 fetchedModelData.autoCreateConstitution || false,
-              apiKeys: fetchedModelData.apiKeys || [],
-              owner: fetchedModelData.owner,
+              apiKeys: [],
+              owner: {
+                uid: fetchedModelData.owner.clerkUserId || "",
+                name: fetchedModelData.owner.name,
+                clerkUserId: fetchedModelData.owner.clerkUserId || "",
+              },
             });
             setActiveZones([
               "about",

--- a/apps/web/lib/components/CommunityModelFlow.tsx
+++ b/apps/web/lib/components/CommunityModelFlow.tsx
@@ -182,7 +182,7 @@ export default function CommunityModelFlow({
           principles: data.principles?.map((p) => ({
             id: p.id,
             text: p.text,
-            gacScore: p.gacScore ?? null
+            gacScore: p.gacScore
           })),
         });
         setModelId(newModelId);

--- a/apps/web/lib/components/flow/AdvancedZone.tsx
+++ b/apps/web/lib/components/flow/AdvancedZone.tsx
@@ -16,6 +16,8 @@ interface AdvancedZoneProps {
   savingStatus: "idle" | "saving" | "saved";
   apiEnabled?: boolean;
   advancedOptionsEnabled?: boolean;
+  autoCreateConstitution?: boolean;
+  onUpdateAutoCreateConstitution?: (enabled: boolean) => void;
   pollOptions?: {
     minVotesBeforeSubmission: number | null;
     maxVotesPerParticipant: number | null;
@@ -48,6 +50,8 @@ export default function AdvancedZone({
   savingStatus,
   apiEnabled = false,
   advancedOptionsEnabled = false,
+  autoCreateConstitution = false,
+  onUpdateAutoCreateConstitution,
   pollOptions = {
     minVotesBeforeSubmission: null,
     maxVotesPerParticipant: null,
@@ -311,7 +315,52 @@ export default function AdvancedZone({
       savingStatus={savingStatus}
     >
       <div className="bg-gray-50 p-6 rounded-lg">
-        {advancedOptionsEnabled && renderPollOptionsSection()}
+        {advancedOptionsEnabled && (
+          <>
+            <div className="mb-6">
+              <div className="flex items-center gap-2 mb-4">
+                <FaCog className="w-5 h-5 text-gray-600" />
+                <h3 className="text-xl font-semibold">Constitution Settings</h3>
+              </div>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex-grow">
+                    <label
+                      htmlFor="auto-create-constitution"
+                      className="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                      Auto-Create Constitution
+                    </label>
+                    <p className="text-sm text-gray-500">
+                      Automatically create and activate new constitutions when
+                      community consensus changes
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={autoCreateConstitution}
+                    className="relative inline-block w-12 h-6 ml-4 cursor-pointer"
+                    onClick={() => {
+                      console.log("Toggle clicked:", !autoCreateConstitution);
+                      onUpdateAutoCreateConstitution?.(!autoCreateConstitution);
+                    }}
+                  >
+                    <div
+                      className={`absolute inset-0 rounded-full transition-colors ${autoCreateConstitution ? "bg-teal" : "bg-gray-300"}`}
+                    >
+                      <span
+                        className={`absolute inset-y-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${autoCreateConstitution ? "translate-x-6" : ""}`}
+                      />
+                    </div>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <hr className="my-6 border-gray-200" />
+            {renderPollOptionsSection()}
+          </>
+        )}
 
         {apiEnabled && (
           <>

--- a/apps/web/lib/data.ts
+++ b/apps/web/lib/data.ts
@@ -107,6 +107,7 @@ export async function getCommunityModel(modelId: string): Promise<
       ownerId: string;
       owner: { uid: string; name: string; clerkUserId: string };
       apiKeys: ApiKey[];
+      advancedOptionsEnabled: boolean;
     })
   | null
 > {
@@ -154,5 +155,6 @@ export async function getCommunityModel(modelId: string): Promise<
       clerkUserId: model.owner.clerkUserId || "",
     },
     apiKeys: model.apiKeys || [],
+    advancedOptionsEnabled: model.advancedOptionsEnabled || false,
   };
 }

--- a/apps/web/lib/data.ts
+++ b/apps/web/lib/data.ts
@@ -95,22 +95,33 @@ export async function getPollData(
   } as ExtendedPoll;
 }
 
-export async function getCommunityModel(modelId: string): Promise<
-  | (CommunityModel & {
-      principles: Array<{ id: string; text: string; gacScore?: number }>;
-      requireAuth: boolean;
-      allowContributions: boolean;
-      constitutions: Constitution[];
-      activeConstitution: Constitution | null;
-      polls: Poll[];
-      published: boolean;
-      ownerId: string;
-      owner: { uid: string; name: string; clerkUserId: string };
-      apiKeys: ApiKey[];
-      advancedOptionsEnabled: boolean;
-    })
-  | null
-> {
+export async function getCommunityModel(modelId: string): Promise<{
+  uid: string;
+  name: string;
+  bio: string | null;
+  goal: string | null;
+  logoUrl: string | null;
+  published: boolean;
+  apiEnabled: boolean;
+  advancedOptionsEnabled: boolean;
+  autoCreateConstitution: boolean;
+  owner: {
+    clerkUserId: string | null;
+    name: string;
+    email: string;
+    imageUrl: string | null;
+  };
+  principles: Array<{
+    id: string;
+    text: string;
+    gacScore: number | null;
+  }>;
+  polls: Poll[];
+  constitutions: Constitution[];
+  activeConstitutionId: string | null;
+  requireAuth: boolean;
+  allowContributions: boolean;
+}> {
   const model = await prisma.communityModel.findUnique({
     where: { uid: modelId },
     include: {
@@ -125,36 +136,42 @@ export async function getCommunityModel(modelId: string): Promise<
         },
       },
       constitutions: true,
-      activeConstitution: true,
-      apiKeys: true,
     },
   });
 
   if (!model) {
-    return null;
+    throw new Error(`Community model with ID ${modelId} not found`);
   }
 
   const firstPoll = model.polls[0];
+  const principles =
+    firstPoll?.statements.map((s) => ({
+      id: s.uid,
+      text: s.text,
+      gacScore: s.gacScore,
+    })) || [];
 
   return {
-    ...model,
-    principles:
-      firstPoll?.statements.map((s: Statement & { votes: Vote[] }) => ({
-        id: s.uid,
-        text: s.text,
-        gacScore: s.gacScore || undefined,
-      })) || [],
+    uid: model.uid,
+    name: model.name,
+    bio: model.bio,
+    goal: model.goal,
+    logoUrl: model.logoUrl,
+    published: model.published,
+    apiEnabled: model.apiEnabled,
+    advancedOptionsEnabled: model.advancedOptionsEnabled,
+    autoCreateConstitution: model.autoCreateConstitution,
+    owner: {
+      clerkUserId: model.owner.clerkUserId,
+      name: model.owner.name,
+      email: model.owner.email,
+      imageUrl: null, // Note: Add this field to CommunityModelOwner if needed
+    },
+    principles,
+    polls: model.polls,
+    constitutions: model.constitutions,
+    activeConstitutionId: model.activeConstitutionId,
     requireAuth: firstPoll?.requireAuth || false,
     allowContributions: firstPoll?.allowParticipantStatements || false,
-    constitutions: model.constitutions,
-    published: model.published || false,
-    ownerId: model.ownerId,
-    owner: {
-      uid: model.owner.uid,
-      name: model.owner.name || "",
-      clerkUserId: model.owner.clerkUserId || "",
-    },
-    apiKeys: model.apiKeys || [],
-    advancedOptionsEnabled: model.advancedOptionsEnabled || false,
   };
 }

--- a/apps/web/lib/data.ts
+++ b/apps/web/lib/data.ts
@@ -11,7 +11,7 @@ import {
 } from "@prisma/client";
 import { currentUser } from "@clerk/nextjs/server";
 import { isStatementConstitutionable } from "@/lib/utils/pollUtils";
-import type { ExtendedPoll } from "@/lib/types";
+import type { ExtendedPoll, Principle } from "@/lib/types";
 
 export async function getUserCommunityModels() {
   const { userId: clerkUserId } = auth();
@@ -111,11 +111,7 @@ export async function getCommunityModel(modelId: string): Promise<{
     email: string;
     imageUrl: string | null;
   };
-  principles: Array<{
-    id: string;
-    text: string;
-    gacScore: number | null;
-  }>;
+  principles: Principle[];
   polls: Poll[];
   constitutions: Constitution[];
   activeConstitutionId: string | null;

--- a/apps/web/lib/data.ts
+++ b/apps/web/lib/data.ts
@@ -144,7 +144,7 @@ export async function getCommunityModel(modelId: string): Promise<{
     firstPoll?.statements.map((s) => ({
       id: s.uid,
       text: s.text,
-      gacScore: s.gacScore,
+      gacScore: s.gacScore ?? null
     })) || [];
 
   return {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -7,10 +7,19 @@ import type {
 } from "@prisma/client";
 
 export interface ExtendedCommunityModel extends CommunityModel {
+  uid: string;
+  name: string;
+  bio: string | null;
+  goal: string | null;
+  logoUrl: string | null;
+  published: boolean;
+  apiEnabled: boolean;
+  advancedOptionsEnabled: boolean;
+  autoCreateConstitution: boolean;
   owner: {
     uid: string;
     name: string;
-    clerkUserId: string | null;
+    clerkUserId: string;
   };
 }
 

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -9,7 +9,7 @@ import type {
 export interface Principle {
   id: string;
   text: string;
-  gacScore?: number;
+  gacScore: number | null;
 }
 
 export interface ExtendedCommunityModel extends CommunityModel {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -9,7 +9,7 @@ import type {
 export interface Principle {
   id: string;
   text: string;
-  gacScore?: number | null;
+  gacScore?: number;
 }
 
 export interface ExtendedCommunityModel extends CommunityModel {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -6,6 +6,12 @@ import type {
   Poll,
 } from "@prisma/client";
 
+export interface Principle {
+  id: string;
+  text: string;
+  gacScore: number | null;
+}
+
 export interface ExtendedCommunityModel extends CommunityModel {
   uid: string;
   name: string;
@@ -21,6 +27,7 @@ export interface ExtendedCommunityModel extends CommunityModel {
     name: string;
     clerkUserId: string;
   };
+  principles: Principle[];
 }
 
 export interface ExtendedStatement extends Statement {

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -9,7 +9,7 @@ import type {
 export interface Principle {
   id: string;
   text: string;
-  gacScore: number | null;
+  gacScore?: number | null;
 }
 
 export interface ExtendedCommunityModel extends CommunityModel {

--- a/apps/web/lib/utils/server/webhooks.ts
+++ b/apps/web/lib/utils/server/webhooks.ts
@@ -26,7 +26,7 @@ export function verifyWebhook(
   rawBody: string,
 ): WebhookVerificationResult {
   const webhookSecret = process.env.WEBHOOK_SECRET;
-  
+
   if (!webhookSecret) {
     console.error("WEBHOOK_SECRET environment variable not set");
     return { isValid: false, error: "Webhook secret not configured" };
@@ -44,7 +44,7 @@ export function verifyWebhook(
   // Use timing-safe comparison
   const signatureBuffer = Buffer.from(signature);
   const expectedBuffer = Buffer.from(expectedSignature);
-  
+
   if (!timingSafeEqual(signatureBuffer, expectedBuffer)) {
     return { isValid: false, error: "Invalid signature" };
   }
@@ -58,7 +58,12 @@ export function verifyWebhook(
   }
 
   // Validate required fields
-  if (!payload.event || !payload.modelId || !payload.pollId || !payload.timestamp) {
+  if (
+    !payload.event ||
+    !payload.modelId ||
+    !payload.pollId ||
+    !payload.timestamp
+  ) {
     return { isValid: false, error: "Missing required fields" };
   }
 
@@ -70,4 +75,4 @@ export function verifyWebhook(
   }
 
   return { isValid: true, payload };
-} 
+}

--- a/apps/web/lib/utils/server/webhooks.ts
+++ b/apps/web/lib/utils/server/webhooks.ts
@@ -1,0 +1,73 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+export interface WebhookPayload {
+  event: string;
+  modelId: string;
+  pollId: string;
+  timestamp: string;
+}
+
+export interface WebhookVerificationResult {
+  isValid: boolean;
+  error?: string;
+  payload?: WebhookPayload;
+}
+
+const MAX_TIMESTAMP_AGE = 5 * 60 * 1000; // 5 minutes in milliseconds
+
+/**
+ * Verify a webhook signature and payload
+ * @param signature The signature from the X-Webhook-Signature header
+ * @param rawBody The raw request body as a string
+ * @returns Object containing verification result and parsed payload if valid
+ */
+export function verifyWebhook(
+  signature: string | null,
+  rawBody: string,
+): WebhookVerificationResult {
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+  
+  if (!webhookSecret) {
+    console.error("WEBHOOK_SECRET environment variable not set");
+    return { isValid: false, error: "Webhook secret not configured" };
+  }
+
+  if (!signature) {
+    return { isValid: false, error: "Missing signature" };
+  }
+
+  // Create expected signature
+  const expectedSignature = createHmac("sha256", webhookSecret)
+    .update(rawBody)
+    .digest("hex");
+
+  // Use timing-safe comparison
+  const signatureBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+  
+  if (!timingSafeEqual(signatureBuffer, expectedBuffer)) {
+    return { isValid: false, error: "Invalid signature" };
+  }
+
+  // Parse and validate payload
+  let payload: WebhookPayload;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch (e) {
+    return { isValid: false, error: "Invalid JSON payload" };
+  }
+
+  // Validate required fields
+  if (!payload.event || !payload.modelId || !payload.pollId || !payload.timestamp) {
+    return { isValid: false, error: "Missing required fields" };
+  }
+
+  // Validate timestamp is recent
+  const timestamp = new Date(payload.timestamp).getTime();
+  const now = Date.now();
+  if (now - timestamp > MAX_TIMESTAMP_AGE) {
+    return { isValid: false, error: "Webhook timestamp too old" };
+  }
+
+  return { isValid: true, payload };
+} 

--- a/apps/web/prisma/migrations/20250128194153_dev/migration.sql
+++ b/apps/web/prisma/migrations/20250128194153_dev/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CommunityModel" ADD COLUMN     "autoCreateConstitution" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -22,25 +22,32 @@ model CommunityModelOwner {
 }
 
 model CommunityModel {
-  uid                    String              @id @default(cuid())
-  name                   String
-  ownerId                String
-  goal                   String?
-  bio                    String?
-  logoUrl                String?
-  activeConstitutionId   String?             @unique
-  createdAt              DateTime            @default(now())
-  updatedAt              DateTime            @updatedAt
-  deleted                Boolean             @default(false)
-  published              Boolean             @default(false)
-  apiEnabled             Boolean             @default(false)
-  advancedOptionsEnabled Boolean             @default(false)
-  apiKeys                ApiKey[]
-  activeConstitution     Constitution?       @relation("ActiveConstitution", fields: [activeConstitutionId], references: [uid])
-  owner                  CommunityModelOwner @relation(fields: [ownerId], references: [uid])
-  constitutions          Constitution[]      @relation("Constitutions")
-  polls                  Poll[]
+  uid                     String                  @id @default(cuid())
+  name                    String
+  ownerId                 String
+  owner                   CommunityModelOwner     @relation(fields: [ownerId], references: [uid])
 
+  goal                    String?
+  bio                     String?
+  logoUrl                 String?
+
+  // Reference to the active constitution for this community model
+  activeConstitutionId    String?                 @unique
+  activeConstitution      Constitution?           @relation("ActiveConstitution", fields: [activeConstitutionId], references: [uid])
+
+  // All constitutions associated with this community model
+  constitutions           Constitution[]          @relation("Constitutions")
+  // Polls created within this community model
+  polls                   Poll[]
+
+  createdAt               DateTime                @default(now())
+  updatedAt               DateTime                @updatedAt
+
+  deleted                  Boolean                 @default(false)
+  published               Boolean                 @default(false)
+  apiEnabled    Boolean    @default(false)  // Feature flag for API access
+  apiKeys       ApiKey[]   // Relation to API keys
+  autoCreateConstitution Boolean        @default(false)
   @@index([ownerId])
 }
 

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -48,6 +48,7 @@ model CommunityModel {
   apiEnabled    Boolean    @default(false)  // Feature flag for API access
   apiKeys       ApiKey[]   // Relation to API keys
   autoCreateConstitution Boolean        @default(false)
+  advancedOptionsEnabled Boolean        @default(false)
   @@index([ownerId])
 }
 


### PR DESCRIPTION
# Auto Constitution Feature Implementation

## Changes Overview
This PR implements the auto-constitution feature for community models, allowing automatic constitution creation whenever the Consensus Service sees a change in which Statements are "constitutionable" after updating GAC scores. Key changes include:

1. Added `autoCreateConstitution` boolean field to the CommunityModel schema
2. Updated CommunityModelFlow component to handle the new auto-constitution setting
3. Enhanced AdvancedZone component to support auto-constitution toggle
4. Added new database migration for the schema changes
5. Updated related API routes and webhook handlers

## Migration Instructions
This PR includes a new migration file: `20250128194153_dev/migration.sql`.

## Testing Instructions
1. Create a new community model
2. Navigate to the Advanced Zone (requires apiEnabled or advancedOptionsEnabled)
3. Toggle the auto-constitution setting
4. Verify that constitutions are automatically created when the setting is enabled after new Votes are given on Statements in a Poll

## Rollback Plan
If issues arise after deployment:
1. The migration can be rolled back using Prisma's migration rollback functionality
2. The feature can be disabled by setting `autoCreateConstitution` to false for all models

## Additional Notes
- This feature is disabled by default (`@default(false)` in schema)
- Only accessible through the Advanced Zone
- Requires either apiEnabled or advancedOptionsEnabled to be true